### PR TITLE
Added Bearer token types.

### DIFF
--- a/src/Provider/Microsoft.php
+++ b/src/Provider/Microsoft.php
@@ -2,15 +2,26 @@
 
 use GuzzleHttp\Psr7\Uri;
 use League\OAuth2\Client\Provider\AbstractProvider;
-use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ResponseInterface;
 
 class Microsoft extends AbstractProvider
 {
-    use BearerAuthorizationTrait;
-    
+    /**
+     * No access token type
+     *
+     * @var string
+     */
+    const ACCESS_TOKEN_TYPE_NONE = '';
+
+    /**
+     * Access token type 'Bearer'
+     *
+     * @var string
+     */
+    const ACCESS_TOKEN_TYPE_BEARER = 'Bearer';
+
     /**
      * Default scopes
      *
@@ -40,6 +51,13 @@ class Microsoft extends AbstractProvider
     protected $urlResourceOwnerDetails = 'https://apis.live.net/v5.0/me';
 
     /**
+     * The access token type to use. Defaults to none.
+     *
+     * @var string
+     */
+    protected $accessTokenType = self::ACCESS_TOKEN_TYPE_NONE;
+
+    /**
      * Get authorization url to begin OAuth flow
      *
      * @return string
@@ -57,6 +75,16 @@ class Microsoft extends AbstractProvider
     public function getBaseAccessTokenUrl(array $params)
     {
         return $this->urlAccessToken;
+    }
+
+    /**
+     * Sets the access token type used for authorization.
+     *
+     * @param string The access token type to use.
+     */
+    public function setAccessTokenType($accessTokenType)
+    {
+        $this->accessTokenType = $accessTokenType;
     }
 
     /**
@@ -111,5 +139,22 @@ class Microsoft extends AbstractProvider
         $uri = new Uri($this->urlResourceOwnerDetails);
 
         return (string) Uri::withQueryValue($uri, 'access_token', (string) $token);
+    }
+
+    /**
+     * Returns the authorization headers used by this provider.
+     *
+     * @param  mixed|null $token Either a string or an access token instance
+     * @return array
+     */
+    protected function getAuthorizationHeaders($token = null)
+    {
+        switch ($this->accessTokenType) {
+            case self::ACCESS_TOKEN_TYPE_BEARER:
+                return ['Authorization' => 'Bearer ' .  $token];
+            case self::ACCESS_TOKEN_TYPE_NONE:
+            default:
+                return [];
+        }
     }
 }

--- a/src/Provider/Microsoft.php
+++ b/src/Provider/Microsoft.php
@@ -2,12 +2,15 @@
 
 use GuzzleHttp\Psr7\Uri;
 use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ResponseInterface;
 
 class Microsoft extends AbstractProvider
 {
+    use BearerAuthorizationTrait;
+    
     /**
      * Default scopes
      *

--- a/tests/src/Provider/MicrosoftTest.php
+++ b/tests/src/Provider/MicrosoftTest.php
@@ -171,4 +171,14 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
+
+    public function testBearerAuthorizationHeader()
+    {
+        $token = uniqid();
+
+        $headers = $this->provider->getHeaders($token);
+
+        $this->assertEquals($headers['Authorization'], 'Bearer ' . $token);
+    }
+
 }

--- a/tests/src/Provider/MicrosoftTest.php
+++ b/tests/src/Provider/MicrosoftTest.php
@@ -177,7 +177,11 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
         $token = uniqid();
 
         $headers = $this->provider->getHeaders($token);
+        $this->assertTrue(!array_key_exists('Authorization', $headers));
 
+        $this->provider->setAccessTokenType(\Stevenmaguire\OAuth2\Client\Provider\Microsoft::ACCESS_TOKEN_TYPE_BEARER);
+        $headers = $this->provider->getHeaders($token);
+        $this->assertArrayHasKey('Authorization', $headers);
         $this->assertEquals($headers['Authorization'], 'Bearer ' . $token);
     }
 


### PR DESCRIPTION
Some Microsoft Office/Outlook OAUTH API's use Bearer tokens. I added the ability to specify the authorization type as either Bearer or none, defaulting to none (the current functionality).