### PR TITLE
Change scope separator into space

### DIFF
--- a/src/Provider/Microsoft.php
+++ b/src/Provider/Microsoft.php
@@ -67,6 +67,16 @@ class Microsoft extends AbstractProvider
     }
 
     /**
+     * Returns the string that will be used to separate scopes in auth url
+     *
+     * @return string Scope separator, defaults to ' '
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+    /**
      * Check a provider response for errors.
      *
      * @throws IdentityProviderException

--- a/tests/src/Provider/MicrosoftTest.php
+++ b/tests/src/Provider/MicrosoftTest.php
@@ -41,7 +41,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $scopeSeparator = ',';
+        $scopeSeparator = ' ';
         $options = ['scope' => [uniqid(), uniqid()]];
         $query = ['scope' => implode($scopeSeparator, $options['scope'])];
         $url = $this->provider->getAuthorizationUrl($options);


### PR DESCRIPTION
A comma for scope separator causes problems when scopes as URL like https://ps.outlook.com/.default are used. With a space it works well.